### PR TITLE
Improve breathing timer UI

### DIFF
--- a/deep_breath_illumination_merged.html
+++ b/deep_breath_illumination_merged.html
@@ -28,6 +28,8 @@ h1{font-size:1.6rem;margin-bottom:8px}
 .timings{margin:16px 0}
 .timings .row{display:flex;gap:8px;margin-bottom:8px}
 .timings label{display:flex;align-items:center;gap:4px;flex:1;margin:0}
+.paramtable{width:100%;border-collapse:collapse;margin:16px 0;font-size:.9rem}
+.paramtable th,.paramtable td{border:1px solid #999;padding:4px;text-align:left}
 label{display:block;margin:12px 0 4px;font-size:.9rem}
 select,input[type="number"],input[type="color"]{
   width:100%;padding:6px 8px;font-size:1rem;border:none;border-radius:4px;margin-bottom:12px
@@ -73,24 +75,17 @@ button:disabled{opacity:.6}
     <option value="custom">カスタム</option>
   </select>
 
-  <div id="customInputs" class="timings">
-    <div class="row">
-      <label>吸う秒数: <input type="number" id="inhaleSec" min="1" value="5"></label>
-      <label>吸う色: <input type="color" id="colorInhale" value="#76c7c0"></label>
-    </div>
-    <div class="row">
-      <label>止める秒数: <input type="number" id="holdSec" min="0" value="0"></label>
-      <label>止める色: <input type="color" id="colorHold" value="#f7c59f"></label>
-    </div>
-    <div class="row">
-      <label>吐く秒数: <input type="number" id="exhaleSec" min="1" value="5"></label>
-      <label>吐く色: <input type="color" id="colorExhale" value="#ff6f61"></label>
-    </div>
-    <div class="row">
-      <label>止める秒数: <input type="number" id="restSec" min="0" value="0"></label>
-      <label>止める色: <input type="color" id="colorRest" value="#74b9ff"></label>
-    </div>
-  </div>
+  <table id="customInputs" class="paramtable">
+    <thead>
+      <tr><th></th><th>秒数</th><th>色</th></tr>
+    </thead>
+    <tbody>
+      <tr><th>吸う</th><td><input type="number" id="inhaleSec" min="1" value="5"></td><td><input type="color" id="colorInhale" value="#76c7c0"></td></tr>
+      <tr><th>止める</th><td><input type="number" id="holdSec" min="0" value="0"></td><td><input type="color" id="colorHold" value="#f7c59f"></td></tr>
+      <tr><th>吐く</th><td><input type="number" id="exhaleSec" min="1" value="5"></td><td><input type="color" id="colorExhale" value="#ff6f61"></td></tr>
+      <tr><th>止める</th><td><input type="number" id="restSec" min="0" value="0"></td><td><input type="color" id="colorRest" value="#74b9ff"></td></tr>
+    </tbody>
+  </table>
 
   <div class="timings">
     <div class="row">
@@ -101,18 +96,18 @@ button:disabled{opacity:.6}
 
   <table class="patterns">
     <thead>
-      <tr><th>呼吸リズム</th><th>名称</th><th>主な目的・適用シーン</th><th>主な身体的変化</th><th>主な心理的変化</th><th>推奨回数*</th></tr>
+      <tr><th>呼吸リズム</th><th>名称</th><th>主な目的・適用シーン</th><th>主な身体的変化</th><th>主な心理的変化</th><th>推奨回数/時間</th></tr>
     </thead>
     <tbody>
       <tr><td>4-7-8</td><td>4-7-8ブリージング</td><td>入眠前・急性不安の鎮静</td><td>HRV↑、心拍↓、血圧↓</td><td>入眠時間短縮、主観的不安↓</td><td>4セット</td></tr>
-      <tr><td>4-4-4-4</td><td>ボックス</td><td>高ストレス下での集中維持（軍・警察訓練ほか）</td><td>副交感優位化、コルチゾール↓</td><td>集中力↑、情動コントロール</td><td>2-3分</td></tr>
+      <tr><td>4-4-4-4</td><td>ボックス</td><td>高ストレス下での集中維持（軍・警察訓練ほか）</td><td>副交感優位化、コルチゾール↓</td><td>集中力↑、情動コントロール</td><td>3分</td></tr>
       <tr><td>5-5</td><td>レゾナンス</td><td>HRV最大化、長期ストレス耐性</td><td>HRV↑、血圧変動整流</td><td>気分安定、認知柔軟性↑</td><td>5分</td></tr>
       <tr><td>3.3-6.7</td><td>ワンツー呼吸法</td><td>仕事中・運転後のクールダウン</td><td>末梢血流↑、心拍↓</td><td>ストレススコア↓、気分回復</td><td>5分</td></tr>
-      <tr><td>7-11</td><td>7-11ブリージング</td><td>急性の緊張緩和、舞台前・商談前</td><td>呼吸数↓、迷走神経刺激</td><td>不安↓、落ち着き↑</td><td>2-3分</td></tr>
-      <tr><td>4-2-4</td><td>タクティカルブリージング</td><td>即応パフォーマンス維持（射撃・試験前）</td><td>SpO₂安定、心拍リセット</td><td>パフォーマンス維持、不安↓</td><td>1-2分</td></tr>
+      <tr><td>7-11</td><td>7-11ブリージング</td><td>急性の緊張緩和、舞台前・商談前</td><td>呼吸数↓、迷走神経刺激</td><td>不安↓、落ち着き↑</td><td>3分</td></tr>
+      <tr><td>4-2-4</td><td>タクティカルブリージング</td><td>即応パフォーマンス維持（射撃・試験前）</td><td>SpO₂安定、心拍リセット</td><td>パフォーマンス維持、不安↓</td><td>2分</td></tr>
     </tbody>
   </table>
-  <p style="font-size:.8rem;opacity:.6">* 推奨回数は一般的なガイドラインの目安です。体調や目的に合わせて調整してください。</p>
+  <p style="font-size:.8rem;opacity:.6">* 推奨回数/時間は一般的なガイドラインの目安です。体調や目的に合わせて調整してください。</p>
 
   <div class="mode-select">
     <label><input type="radio" name="mode" value="expand" checked> 光の広がり</label>
@@ -870,13 +865,30 @@ VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
   const minuteInput   = document.getElementById('totalMinutes');
   const applyBtn      = document.getElementById('applyBtn');
 
+  const defaultBg = 'https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?auto=format&fit=crop&w=1400&q=60';
+  const bgMap = {
+    off: defaultBg,
+    wave: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1400&q=60',
+    birds: 'https://images.unsplash.com/photo-1502082553048-f009c37129b9?auto=format&fit=crop&w=1400&q=60',
+    onsen: 'https://images.unsplash.com/photo-1587502537104-89e3965dcf17?auto=format&fit=crop&w=1400&q=60',
+    bubble: 'https://images.unsplash.com/photo-1607631396276-57e68cb0a81a?auto=format&fit=crop&w=1400&q=60',
+    wind: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=60',
+    shishi: 'https://images.unsplash.com/photo-1501471986900-23040e4a971c?auto=format&fit=crop&w=1400&q=60',
+    rain: 'https://images.unsplash.com/photo-1526676038764-6bf7ddbd038d?auto=format&fit=crop&w=1400&q=60'
+  };
+
+  function updateBackground(){
+    const url = bgMap[soundSel.value] || defaultBg;
+    document.body.style.background = `#000 url('${url}') center/cover no-repeat fixed`;
+  }
+
   const recommendedMap = {
     '4-7-8-0': '4セット',
-    '4-4-4-4': '2-3分',
+    '4-4-4-4': '3分',
     '5-0-5-0': '5分',
     '3.3-0-6.7-0': '5分',
-    '7-0-11-0': '2-3分',
-    '4-2-4-0': '1-2分'
+    '7-0-11-0': '3分',
+    '4-2-4-0': '2分'
   };
 
   let timerId = null;
@@ -921,6 +933,8 @@ VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
 
   patternSelect.addEventListener('change', updateInputsFromPattern);
   updateInputsFromPattern();
+  soundSel.addEventListener('change', updateBackground);
+  updateBackground();
   document.querySelectorAll('input[name="mode"]').forEach(radio => {
     radio.addEventListener('change', e => mode = e.target.value);
   });
@@ -1041,7 +1055,10 @@ VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
     if(timerId) clearInterval(timerId);
     timerId = null;
     running = false;
+    breathBar.style.transition = 'none';
     breathBar.style.width = '0%';
+    void breathBar.offsetWidth;
+    breathBar.style.transition = '';
     phaseText.textContent = '準備中...';
     timerText.textContent = '--';
     startBtn.disabled = false;
@@ -1089,8 +1106,12 @@ VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
 
     if(currentPhase === 0){
       playPhase(duration,0,1);
+    } else if(currentPhase === 1){
+      playPhase(duration,1,1);
     } else if(currentPhase === 2){
       playPhase(duration,1,0);
+    } else if(currentPhase === 3){
+      playPhase(duration,0,0);
     }
 
     if(duration === 0){


### PR DESCRIPTION
## Summary
- layout param inputs in a small table
- update recommendations header wording
- tweak recommended times in table and logic
- set background image based on sound selection
- keep audio playing during first hold, silence during second
- reset bar instantly when stopped

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68442e8315508326a7e38bd8ff634bd2