### PR TITLE
Update button layout and fade color behavior

### DIFF
--- a/deep_breath_illumination_merged.html
+++ b/deep_breath_illumination_merged.html
@@ -48,9 +48,9 @@ select,input[type="number"],input[type="color"]{
 .section h3{margin-bottom:8px;font-weight:600}
 .mode-buttons button,.env-buttons button,.switch-buttons button,.music-buttons button{
   margin:0;padding:0;font-size:.8rem;cursor:pointer;border:2px solid transparent;border-radius:0;
-  background:transparent;color:#fff;flex:0 0 auto;width:72px;height:72px;
-  display:flex;flex-direction:column;align-items:center;justify-content:center;
-  aspect-ratio:1/1;
+  background:transparent;color:#fff;flex:0 0 auto;width:12.5%;
+  display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;
+  white-space:nowrap;text-align:center;
 }
 .mode-buttons button.active,.env-buttons button.active,.switch-buttons button.active,.music-buttons button.active{
   background:rgba(255,255,255,.2);color:#000;border-color:#fff;
@@ -76,8 +76,13 @@ button:disabled{opacity:.6}
 .controls{display:flex;gap:8px;justify-content:center;margin-top:16px}
 .scroll-buttons{display:flex;gap:8px;justify-content:center;overflow-x:auto;-ms-overflow-style:none;scrollbar-width:none}
 .scroll-buttons::-webkit-scrollbar{display:none}
-.mode-buttons img,.env-buttons img,.switch-buttons img,.music-buttons img{width:100%;height:100%;object-fit:cover}
-.noimg{width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:#555;color:#fff;font-size:.6rem}
+.mode-buttons img,.env-buttons img,.switch-buttons img,.music-buttons img{
+  width:100%;aspect-ratio:1/1;object-fit:cover
+}
+.noimg{
+  width:100%;aspect-ratio:1/1;display:flex;align-items:center;justify-content:center;
+  background:#555;color:#fff;font-size:.6rem
+}
 @media(hover:hover) and (pointer:fine){button:hover{filter:brightness(.9);border-color:rgba(255,255,255,.6)}}
 </style>
 </head>
@@ -363,12 +368,18 @@ button:disabled{opacity:.6}
     sc.addEventListener('pointercancel',end);
   });
   updateBackground();
+  restoreDefaultColors();
   modeBtns.forEach(btn => {
     if(btn.dataset.mode===mode) btn.classList.add('active');
     btn.addEventListener('click', () => {
       modeBtns.forEach(b=>b.classList.remove('active'));
       btn.classList.add('active');
       mode = btn.dataset.mode;
+      if(mode === 'fade'){
+        applyFadeColors();
+      } else {
+        restoreDefaultColors();
+      }
     });
   });
 
@@ -448,6 +459,28 @@ button:disabled{opacity:.6}
   const colorHold   = document.getElementById('colorHold');
   const colorExhale = document.getElementById('colorExhale');
   const colorRest   = document.getElementById('colorRest');
+  const defaultColors = {
+    hold: colorHold.value,
+    exhale: colorExhale.value,
+    rest: colorRest.value
+  };
+
+  function applyFadeColors(){
+    const c = colorInhale.value;
+    colorHold.value = c;
+    colorExhale.value = c;
+    colorRest.value = c;
+  }
+
+  function restoreDefaultColors(){
+    colorHold.value = defaultColors.hold;
+    colorExhale.value = defaultColors.exhale;
+    colorRest.value = defaultColors.rest;
+  }
+
+  colorInhale.addEventListener('change', () => {
+    if(mode === 'fade') applyFadeColors();
+  });
 
   function getColors(){
     return [


### PR DESCRIPTION
## Summary
- ensure button images remain square and wider so text is below
- keep "鳥のさえずり" on one line with nowrap
- when selecting fade mode, sync hold/exhale/rest colors with inhale color and restore defaults for other modes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68468ae89be08326b265282b5e98eb9a