### PR TITLE
Fix start/settings unresponsive due to color initialization

### DIFF
--- a/deep_breath_illumination_merged.html
+++ b/deep_breath_illumination_merged.html
@@ -368,7 +368,6 @@ button:disabled{opacity:.6}
     sc.addEventListener('pointercancel',end);
   });
   updateBackground();
-  restoreDefaultColors();
   modeBtns.forEach(btn => {
     if(btn.dataset.mode===mode) btn.classList.add('active');
     btn.addEventListener('click', () => {
@@ -481,6 +480,8 @@ button:disabled{opacity:.6}
   colorInhale.addEventListener('change', () => {
     if(mode === 'fade') applyFadeColors();
   });
+
+  restoreDefaultColors();
 
   function getColors(){
     return [


### PR DESCRIPTION
## Summary
- fix reference error when `restoreDefaultColors` ran before variables were defined

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684698fb92d48326a55fc8a5c1d3accd