### PR TITLE
Refine settings layout and volume control

### DIFF
--- a/deep_breath_illumination_merged.html
+++ b/deep_breath_illumination_merged.html
@@ -24,12 +24,13 @@ body{
   position:relative;z-index:1;width:min(95%,1040px);
   background:rgba(0,0,0,.6);border-radius:14px;padding:clamp(1rem,4vw,2rem);text-align:center;
   backdrop-filter:blur(12px);
-  max-height:100vh;overflow-y:auto;overflow-x:hidden;scrollbar-width:thin;scrollbar-color:rgba(255,255,255,.3) transparent;
+  height:100vh;display:flex;flex-direction:column;overflow:hidden;
+  scrollbar-width:thin;scrollbar-color:rgba(255,255,255,.3) transparent;
 }
 .container::-webkit-scrollbar{width:6px}
 .container::-webkit-scrollbar-track{background:transparent}
 .container::-webkit-scrollbar-thumb{background:rgba(255,255,255,.3);border-radius:3px}
-h1{font-size:1.6rem;margin-bottom:8px}
+.container h1{font-size:1.6rem;margin-bottom:4px}
 .paramtable{width:100%;border-collapse:collapse;margin:16px 0;font-size:.9rem}
 #customInputs{width:50%;margin:16px auto}
 .paramtable th,.paramtable td{border:1px solid #999;padding:4px;text-align:center}
@@ -40,15 +41,15 @@ select,input[type="number"],input[type="color"]{
   background:rgba(255,255,255,.2);color:#fff;border:1px solid rgba(255,255,255,.3);
   backdrop-filter:blur(6px);
 }
-.patterns{width:100%;border-collapse:collapse;margin:16px auto;font-size:.8rem;table-layout:fixed}
+.patterns{width:100%;border-collapse:collapse;margin:12px auto;font-size:.8rem}
 .patterns th,.patterns td{
   border:1px solid #999;padding:4px;font-size:min(.8rem,2.5vw);
   white-space:normal;line-height:1.2em;height:2.4em;
 }
 .patterns tbody tr.selected{background:rgba(255,255,255,.3)}
 .patterns tbody tr:hover{background:rgba(255,255,255,.2)}
-.section{margin:16px 0}
-.section h3{margin-bottom:8px;font-weight:600}
+.section{margin:12px 0}
+.section h3{margin-bottom:4px;font-weight:600}
 .mode-buttons button,.env-buttons button,.switch-buttons button,.music-buttons button{
   margin:0;padding:0;font-size:.8rem;cursor:pointer;border:2px solid transparent;border-radius:0;
   background:transparent;color:#fff;flex:0 0 auto;width:12.5%;
@@ -60,7 +61,7 @@ select,input[type="number"],input[type="color"]{
 }
 .mode-buttons{margin:0}
 #barContainer{
-  position:relative;margin:24px auto;width:100%;max-width:1120px;height:40px;
+  position:relative;margin:16px auto;width:100%;max-width:1120px;height:40px;
   background:#444;border-radius:20px;overflow:hidden
 }
 #breathBar{
@@ -76,7 +77,7 @@ button{
 #startBtn{background:rgba(118,199,192,.5);color:#fff}
 #applyBtn{background:rgba(116,185,255,.5);color:#fff}
 button:disabled{opacity:.6}
-.controls{display:flex;gap:8px;justify-content:center;margin-top:16px}
+.controls{display:flex;gap:8px;justify-content:center;margin-top:8px}
 .scroll-buttons{display:flex;gap:8px;justify-content:center;overflow-x:auto;-ms-overflow-style:none;scrollbar-width:none}
 .scroll-buttons::-webkit-scrollbar{display:none}
 .mode-buttons img,.env-buttons img,.switch-buttons img,.music-buttons img{
@@ -86,8 +87,9 @@ button:disabled{opacity:.6}
   width:100%;aspect-ratio:1/1;display:flex;align-items:center;justify-content:center;
   background:#555;color:#fff;font-size:.6rem
 }
+#phaseText,#timerText{margin:4px 0}
 #fixedArea{position:sticky;top:0;background:rgba(0,0,0,.6);padding-bottom:8px;z-index:2}
-#settings{max-height:calc(100dvh - 240px);overflow-y:auto}
+#settings{flex:1;overflow-y:auto}
 @media(hover:hover) and (pointer:fine){button:hover{filter:brightness(.9);border-color:rgba(255,255,255,.6)}}
 </style>
 </head>
@@ -208,7 +210,7 @@ button:disabled{opacity:.6}
   <input type="hidden" id="switchSound" value="off">
   <input type="hidden" id="musicSel" value="off">
 
-  <footer style="margin-top:16px;font-size:.7rem;opacity:.5">v3 – Generated 2025-06-06 07:59:20</footer>
+  <footer style="margin-top:8px;font-size:.7rem;opacity:.5">v3 – Generated 2025-06-06 07:59:20</footer>
 </div>
 
 <script>
@@ -227,6 +229,7 @@ button:disabled{opacity:.6}
   const applyBtn      = document.getElementById('applyBtn');
   const settings      = document.getElementById('settings');
   const settingsBtn   = document.getElementById('settingsBtn');
+  const footer        = document.querySelector('footer');
   const patternRows   = document.querySelectorAll('.patterns tbody tr');
   const modeBtns      = document.querySelectorAll('.modeBtn');
   const envBtns       = document.querySelectorAll('.envBtn');
@@ -414,7 +417,7 @@ button:disabled{opacity:.6}
   function handleMusic(forceStop=false){
     Object.values(musicAudios).forEach(a=>{try{a.pause();}catch{} if(forceStop) a.currentTime=0;});
     if(!forceStop && running && musicSel.value==='canon'){
-      const el = musicAudios.canon; el.volume=1; el.play().catch(()=>{});
+      const el = musicAudios.canon; el.volume=0.8; el.play().catch(()=>{});
     }
   }
 
@@ -423,14 +426,14 @@ button:disabled{opacity:.6}
     selectedEnvs.forEach(env=>{
       const el = envAudios[env];
       if(!el) return;
-      el.volume = from;
+      el.volume = from * 0.8;
       if(el.paused) el.play().catch(()=>{});
-      const diff = to-from;
+      const diff = to - from;
       const steps = Math.max(1,Math.floor(dur*10));
       let c=0;
       clearInterval(el._fade);
       el._fade=setInterval(()=>{
-        c++; el.volume = from + diff*c/steps;
+        c++; el.volume = (from + diff*c/steps) * 0.8;
         if(c>=steps){
           clearInterval(el._fade);
           if(to===0){ try{el.pause();}catch{} el.currentTime=0; }
@@ -654,7 +657,12 @@ button:disabled{opacity:.6}
     const open = settings.style.display !== 'none';
     settings.style.display = open ? 'none' : '';
     settingsBtn.textContent = open ? '設定' : '閉じる';
-    if(open) applyBtn.style.display='none';
+    if(open){
+      applyBtn.style.display='none';
+      footer.style.display='';
+    }else{
+      footer.style.display='none';
+    }
   });
 })();
 </script>


### PR DESCRIPTION
## Summary
- tweak spacing around title, controls, and footer
- scroll only the settings panel
- cap environment & music volume at 80%
- hide footer while settings are open
- allow breathing rhythm table to auto size

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847d07d02f0832693f78e70246125c7