### PR TITLE
Fix audio fade and iPhone layout

### DIFF
--- a/deep_breath_illumination_merged.html
+++ b/deep_breath_illumination_merged.html
@@ -61,7 +61,11 @@ select,input[type="number"],input[type="color"]{
 }
 .mode-buttons{margin:0}
 #barContainer{
-  position:relative;margin:16px auto;width:100%;max-width:1120px;height:40px;
+  position:relative;
+  margin:16px calc(-50vw + 50%);
+  width:100vw;
+  max-width:none;
+  height:40px;
   background:#444;border-radius:20px;overflow:hidden
 }
 #breathBar{
@@ -89,7 +93,7 @@ button:disabled{opacity:.6}
 }
 #phaseText,#timerText{margin:4px 0}
 #fixedArea{position:sticky;top:0;background:rgba(0,0,0,.6);padding-bottom:8px;z-index:2}
-#settings{flex:1;overflow-y:auto}
+#settings{flex:1;overflow-y:auto;overflow-x:hidden}
 @media(hover:hover) and (pointer:fine){button:hover{filter:brightness(.9);border-color:rgba(255,255,255,.6)}}
 </style>
 </head>
@@ -396,22 +400,36 @@ button:disabled{opacity:.6}
     });
   });
 
+  const audioCtx = new (window.AudioContext||window.webkitAudioContext)();
+  function createEnvAudio(src){
+    const audio = new Audio(src);
+    const node  = audioCtx.createMediaElementSource(audio);
+    const gain  = audioCtx.createGain();
+    node.connect(gain).connect(audioCtx.destination);
+    audio.loop = true;
+    return {audio,gain,fade:null};
+  }
   const envAudios = {
-    wave:new Audio('波の音.mp3'),
-    birds:new Audio('鳥のさえずり.mp3'),
-    onsen:new Audio('温泉の音.mp3'),
-    bubble:new Audio('泡風呂.mp3'),
-    wind:new Audio('風の音.mp3'),
-    rain:new Audio('雨の音.mp3'),
-    kirakira:new Audio('キラキラ.mp3')
+    wave:createEnvAudio('波の音.mp3'),
+    birds:createEnvAudio('鳥のさえずり.mp3'),
+    onsen:createEnvAudio('温泉の音.mp3'),
+    bubble:createEnvAudio('泡風呂.mp3'),
+    wind:createEnvAudio('風の音.mp3'),
+    rain:createEnvAudio('雨の音.mp3'),
+    kirakira:createEnvAudio('キラキラ.mp3')
   };
-  Object.values(envAudios).forEach(a=>a.loop=true);
   const switchAudios = {shishi:new Audio('ししおどし.mp3')};
   const musicAudios = {canon:new Audio('カノン.m4a')};
 
   function stopEnvSound(env){
-    const el = envAudios[env];
-    if(el){ if(el._fade) clearInterval(el._fade); try{el.pause();}catch{} el.currentTime=0; }
+    const obj = envAudios[env];
+    if(obj){
+      if(obj.fade) clearInterval(obj.fade);
+      try{obj.audio.pause();}catch{}
+      obj.audio.currentTime = 0;
+      obj.gain.gain.cancelScheduledValues(audioCtx.currentTime);
+      obj.gain.gain.setValueAtTime(0, audioCtx.currentTime);
+    }
   }
 
   function handleMusic(forceStop=false){
@@ -424,21 +442,16 @@ button:disabled{opacity:.6}
   function playEnv(dur, from, to){
     if(selectedEnvs.length===0) return;
     selectedEnvs.forEach(env=>{
-      const el = envAudios[env];
-      if(!el) return;
-      el.volume = from * 0.8;
-      if(el.paused) el.play().catch(()=>{});
-      const diff = to - from;
-      const steps = Math.max(1,Math.floor(dur*10));
-      let c=0;
-      clearInterval(el._fade);
-      el._fade=setInterval(()=>{
-        c++; el.volume = (from + diff*c/steps) * 0.8;
-        if(c>=steps){
-          clearInterval(el._fade);
-          if(to===0){ try{el.pause();}catch{} el.currentTime=0; }
-        }
-      },100);
+      const obj = envAudios[env];
+      if(!obj) return;
+      if(obj.audio.paused) obj.audio.play().catch(()=>{});
+      obj.gain.gain.cancelScheduledValues(audioCtx.currentTime);
+      obj.gain.gain.setValueAtTime(from*0.8, audioCtx.currentTime);
+      obj.gain.gain.linearRampToValueAtTime(to*0.8, audioCtx.currentTime + dur);
+      if(obj.fade) clearInterval(obj.fade);
+      if(to===0){
+        obj.fade = setTimeout(()=>{ try{obj.audio.pause();}catch{} obj.audio.currentTime=0; }, dur*1000+50);
+      }
     });
   }
 
@@ -523,9 +536,16 @@ button:disabled{opacity:.6}
     timerText.textContent = '--';
     startBtn.disabled = false;
     startBtn.textContent = 'スタート';
-    Object.values(envAudios).forEach(el=>{if(el._fade) clearInterval(el._fade); try{el.pause();}catch{} el.currentTime=0;});
+    Object.values(envAudios).forEach(obj=>{
+      if(obj.fade) clearTimeout(obj.fade);
+      try{obj.audio.pause();}catch{}
+      obj.audio.currentTime = 0;
+      obj.gain.gain.cancelScheduledValues(audioCtx.currentTime);
+      obj.gain.gain.setValueAtTime(0, audioCtx.currentTime);
+    });
     Object.values(switchAudios).forEach(el=>{try{el.pause();}catch{} el.currentTime=0;});
     handleMusic(true);
+    audioCtx.suspend();
   }
 
   function nextPhase(){
@@ -624,6 +644,7 @@ button:disabled{opacity:.6}
   }
 
   async function startSession(){
+    await audioCtx.resume();
     running = true;
     currentPhase = 0;
     cyclesDone = 0;


### PR DESCRIPTION
## Summary
- improve width of light bar to match viewport
- prevent horizontal scroll of settings panel
- use Web Audio API for smoother volume fades
- resume/suspend audio context when sessions start/stop

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848aefcb7388326b82ba7ea73d99dbf