### PR TITLE
Fix horizontal clipping of breathing bar

### DIFF
--- a/deep_breath_illumination_merged.html
+++ b/deep_breath_illumination_merged.html
@@ -24,7 +24,8 @@ body{
   position:relative;z-index:1;width:min(95%,1040px);
   background:rgba(0,0,0,.6);border-radius:14px;padding:clamp(1rem,4vw,2rem);text-align:center;
   backdrop-filter:blur(12px);
-  height:100vh;display:flex;flex-direction:column;overflow:hidden;
+  height:100vh;display:flex;flex-direction:column;
+  overflow-y:hidden;overflow-x:visible;
   scrollbar-width:thin;scrollbar-color:rgba(255,255,255,.3) transparent;
 }
 .container::-webkit-scrollbar{width:6px}


### PR DESCRIPTION
## Summary
- allow horizontal overflow in the main container so the breathing bar remains visible when stretched to screen edges

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848b30afbdc832690f2081a06534e52