### PR TITLE
Implement shape selection and add water ambient

### DIFF
--- a/deep_breath_illumination_merged.html
+++ b/deep_breath_illumination_merged.html
@@ -53,19 +53,20 @@ select,input[type="number"],input[type="color"]{
 .patterns tbody tr:hover{background:rgba(255,255,255,.2)}
 .section{margin:12px 0}
 .section h3{margin-bottom:4px;font-weight:600}
-.mode-buttons button,.env-buttons button,.switch-buttons button,.music-buttons button{
+.mode-buttons button,.env-buttons button,.switch-buttons button,.music-buttons button,.shape-buttons button{
   margin:0;padding:0;font-size:.8rem;cursor:pointer;border:2px solid transparent;border-radius:0;
   background:transparent;color:#fff;flex:0 0 auto;width:12.5%;
   display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;
   white-space:nowrap;text-align:center;
 }
-.mode-buttons button.active,.env-buttons button.active,.switch-buttons button.active,.music-buttons button.active{
+.mode-buttons button.active,.env-buttons button.active,.switch-buttons button.active,.music-buttons button.active,.shape-buttons button.active{
   background:rgba(255,255,255,.2);color:#000;border-color:#fff;
 }
 .mode-buttons{margin:0}
+.shape-buttons{margin:0}
 #barContainer{
   position:fixed;
-  top:80px;
+  top:240px;
   left:0;
   width:100%;
   height:40px;
@@ -80,6 +81,17 @@ select,input[type="number"],input[type="color"]{
   background:#fff;border-radius:20px;transform:translateX(-50%);
   transform-origin:center;border-radius:20px;
   transition:width 1s linear,background-color .8s
+}
+#breathPlane{
+  position:fixed;
+  inset:0;
+  background:#fff;
+  transform:scale(0);
+  transform-origin:center;
+  transition:transform 1s linear,background-color .8s linear;
+  pointer-events:none;
+  z-index:3;
+  display:none
 }
 button{
   margin:4px;padding:10px;font-size:1rem;font-weight:600;border:none;border-radius:0;cursor:pointer;width:100%;
@@ -111,6 +123,7 @@ button:disabled{opacity:.6}
 <body>
 <div class="overlay"></div>
 <div id="barContainer"><div id="breathBar"></div></div>
+<div id="breathPlane"></div>
 <div class="container">
   <div id="fixedArea">
     <h1>深呼吸誘発システム</h1>
@@ -196,6 +209,15 @@ button:disabled{opacity:.6}
   </table>
 
   <div class="section">
+    <h3>光の形状</h3>
+    <div class="shape-buttons scroll-buttons">
+      <button type="button" class="shapeBtn" data-shape="none"><div class="noimg">画像なし</div> なし</button>
+      <button type="button" class="shapeBtn active" data-shape="line"><div class="noimg">バー</div> 線</button>
+      <button type="button" class="shapeBtn" data-shape="plane"><div class="noimg">面</div> 面</button>
+    </div>
+  </div>
+
+  <div class="section" id="modeSection">
     <h3>光の表現</h3>
     <div class="mode-buttons scroll-buttons">
       <button type="button" class="modeBtn" data-mode="off"><div class="noimg">画像なし</div> なし</button>
@@ -212,6 +234,7 @@ button:disabled{opacity:.6}
       <button type="button" class="envBtn" data-env="birds"><img src="鳥のさえずり.jpg" alt=""> 鳥のさえずり</button>
       <button type="button" class="envBtn" data-env="onsen"><img src="温泉の音.jpg" alt=""> 温泉の音</button>
       <button type="button" class="envBtn" data-env="bubble"><img src="泡風呂.jpeg" alt=""> 泡風呂</button>
+      <button type="button" class="envBtn" data-env="water"><img src="水.jpg" alt=""> 水</button>
       <button type="button" class="envBtn" data-env="wind"><img src="風の音.png" alt=""> 風の音</button>
       <button type="button" class="envBtn" data-env="rain"><img src="雨の音.jpg" alt=""> 雨の音</button>
       <button type="button" class="envBtn" data-env="kirakira"><img src="キラキラ.jpg" alt=""> キラキラ</button>
@@ -262,9 +285,13 @@ button:disabled{opacity:.6}
   const footer        = document.querySelector('footer');
   const patternRows   = document.querySelectorAll('.patterns tbody tr');
   const modeBtns      = document.querySelectorAll('.modeBtn');
+  const shapeBtns     = document.querySelectorAll('.shapeBtn');
   const envBtns       = document.querySelectorAll('.envBtn');
   const switchBtns    = document.querySelectorAll('.switchBtn');
   const musicBtns     = document.querySelectorAll('.musicBtn');
+  const barContainer  = document.getElementById('barContainer');
+  const breathPlane   = document.getElementById('breathPlane');
+  const modeSection   = document.getElementById('modeSection');
   let selectedEnvs = [];
   let lastEnv = 'off';
   const canonMinutes = 431.654/60;
@@ -278,6 +305,7 @@ button:disabled{opacity:.6}
     birds: '鳥のさえずり.jpg',
     onsen: '温泉の音.jpg',
     bubble: '泡風呂.jpeg',
+    water: '水.jpg',
     wind: '風の音.png',
     rain: '雨の音.jpg',
     kirakira: 'キラキラ.jpg'
@@ -300,6 +328,7 @@ button:disabled{opacity:.6}
   let timerId = null;
   let currentPhase = 0;
   let mode = 'expand';
+  let shape = 'line';
   let running = false;
   let cycleLimit = 0;
   let timeLimit  = 0;
@@ -424,6 +453,31 @@ button:disabled{opacity:.6}
     sc.addEventListener('pointercancel',end);
   });
   updateBackground();
+  function updateShapeVisibility(){
+    if(shape==='line'){
+      barContainer.style.display='';
+      breathPlane.style.display='none';
+      modeSection.style.display='';
+    }else if(shape==='plane'){
+      barContainer.style.display='none';
+      breathPlane.style.display='';
+      modeSection.style.display='';
+    }else{
+      barContainer.style.display='none';
+      breathPlane.style.display='none';
+      modeSection.style.display='none';
+    }
+  }
+  updateShapeVisibility();
+  shapeBtns.forEach(btn=>{
+    if(btn.dataset.shape===shape) btn.classList.add('active');
+    btn.addEventListener('click',()=>{
+      shapeBtns.forEach(b=>b.classList.remove('active'));
+      btn.classList.add('active');
+      shape = btn.dataset.shape;
+      updateShapeVisibility();
+    });
+  });
   modeBtns.forEach(btn => {
     if(btn.dataset.mode===mode) btn.classList.add('active');
     btn.addEventListener('click', () => {
@@ -454,6 +508,7 @@ button:disabled{opacity:.6}
     birds:createEnvAudio('鳥のさえずり.mp3'),
     onsen:createEnvAudio('温泉の音.mp3'),
     bubble:createEnvAudio('泡風呂.mp3'),
+    water:createEnvAudio('水.mp3'),
     wind:createEnvAudio('風の音.mp3'),
     rain:createEnvAudio('雨の音.mp3'),
     kirakira:createEnvAudio('キラキラ.mp3')
@@ -573,6 +628,11 @@ button:disabled{opacity:.6}
     breathBar.style.width = widthPercent + '%';
     breathBar.style.backgroundColor = color;
   }
+  function setPlane(scale,dur,color,colorDur){
+    breathPlane.style.transition = `transform ${dur}s linear, background-color ${colorDur}s linear`;
+    breathPlane.style.transform = `scale(${scale})`;
+    breathPlane.style.backgroundColor = color;
+  }
 
   async function stopSession(){
     if(timerId) clearInterval(timerId);
@@ -582,6 +642,11 @@ button:disabled{opacity:.6}
     breathBar.style.width = '0%';
     void breathBar.offsetWidth;
     breathBar.style.transition = '';
+    breathPlane.style.transition = 'none';
+    breathPlane.style.transform = 'scale(0)';
+    breathPlane.style.backgroundColor = 'transparent';
+    void breathPlane.offsetWidth;
+    breathPlane.style.transition = '';
     phaseText.textContent = '準備中...';
     timerText.textContent = '--';
     startBtn.disabled = false;
@@ -627,28 +692,54 @@ button:disabled{opacity:.6}
     const color    = colors[currentPhase];
 
     phaseText.textContent = phaseNames[currentPhase] || '';
-    if(mode === 'expand'){
-      setBar(currentPhase < 2 ? 100 : 0, duration, color, 0.8);
-    } else if(mode === 'color') {
-      setBar(100, 0, color, 0.8);
-    } else if(mode === 'fade') {
-      if(currentPhase === 0){
-        breathBar.style.transition = 'background-color 0s';
-        breathBar.style.backgroundColor = '#000';
-        void breathBar.offsetWidth;
-        setBar(100, 0, color, duration);
-      } else if(currentPhase === 1){
-        setBar(100, 0, color, 0);
-      } else if(currentPhase === 2){
-        breathBar.style.transition = 'background-color 0s';
-        breathBar.style.backgroundColor = color;
-        void breathBar.offsetWidth;
-        setBar(100, 0, '#000', duration);
+    if(shape === 'line'){
+      if(mode === 'expand'){
+        setBar(currentPhase < 2 ? 100 : 0, duration, color, 0.8);
+      } else if(mode === 'color') {
+        setBar(100, 0, color, 0.8);
+      } else if(mode === 'fade') {
+        if(currentPhase === 0){
+          breathBar.style.transition = 'background-color 0s';
+          breathBar.style.backgroundColor = '#000';
+          void breathBar.offsetWidth;
+          setBar(100, 0, color, duration);
+        } else if(currentPhase === 1){
+          setBar(100, 0, color, 0);
+        } else if(currentPhase === 2){
+          breathBar.style.transition = 'background-color 0s';
+          breathBar.style.backgroundColor = color;
+          void breathBar.offsetWidth;
+          setBar(100, 0, '#000', duration);
+        } else {
+          setBar(100, 0, color, 0);
+        }
       } else {
-        setBar(100, 0, color, 0);
+        setBar(0, 0, 'transparent', 0);
       }
-    } else {
-      setBar(0, 0, 'transparent', 0);
+    } else if(shape === 'plane'){
+      if(mode === 'expand'){
+        setPlane(currentPhase < 2 ? 1 : 0, duration, color, 0.8);
+      } else if(mode === 'color'){
+        setPlane(1, 0, color, 0.8);
+      } else if(mode === 'fade'){
+        if(currentPhase === 0){
+          breathPlane.style.transition = 'background-color 0s';
+          breathPlane.style.backgroundColor = '#000';
+          void breathPlane.offsetWidth;
+          setPlane(1, 0, color, duration);
+        } else if(currentPhase === 1){
+          setPlane(1, 0, color, 0);
+        } else if(currentPhase === 2){
+          breathPlane.style.transition = 'background-color 0s';
+          breathPlane.style.backgroundColor = color;
+          void breathPlane.offsetWidth;
+          setPlane(1, 0, '#000', duration);
+        } else {
+          setPlane(1, 0, color, 0);
+        }
+      } else {
+        setPlane(0, 0, 'transparent', 0);
+      }
     }
 
     if(currentPhase === 0){


### PR DESCRIPTION
## Summary
- add shape selection section and plane element
- move breathing bar further down and support plane scaling
- allow selecting water ambience with image and mp3
- show/hide expression options based on shape

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a7d1886c48326b02744c0523cd9d9