### PR TITLE
Fix ambient sound selection

### DIFF
--- a/deep_breath_illumination_merged.html
+++ b/deep_breath_illumination_merged.html
@@ -386,6 +386,13 @@ button:disabled{opacity:.6}
     });
   });
   updateInputsFromPattern();
+  function startEnvSound(env){
+    const obj = envAudios[env];
+    if(!obj) return;
+    if(obj.audio.paused) obj.audio.play().catch(()=>{});
+    obj.gain.gain.cancelScheduledValues(audioCtx.currentTime);
+    obj.gain.gain.setValueAtTime(ENV_MAX_VOL, audioCtx.currentTime);
+  }
   envBtns.forEach(btn => {
     btn.addEventListener('click', async () => {
       await audioCtx.resume();
@@ -401,6 +408,7 @@ button:disabled{opacity:.6}
         if(btn.classList.contains('active')){
           selectedEnvs.push(env);
           lastEnv = env;
+          startEnvSound(env);
         } else {
           selectedEnvs = selectedEnvs.filter(e=>e!==env);
           stopEnvSound(env);


### PR DESCRIPTION
## Summary
- start ambient sounds immediately when choosing environment

## Testing
- `tidy -q -e deep_breath_illumination_merged.html`

------
https://chatgpt.com/codex/tasks/task_e_684a872f72188326881778022a84af7e