### PR TITLE
Fix underwater sound playback timing

### DIFF
--- a/deep_breath_illumination_merged.html
+++ b/deep_breath_illumination_merged.html
@@ -1167,7 +1167,7 @@ function handleMusic(forceStop=false){
         stopEnvSound("underwater");
         diveRiseAudio.currentTime = 0;
         diveRiseAudio.play().catch(()=>{});
-      } else if(currentPhase === 1 || (currentPhase === 2 && holdDur === 0 && prevPhase === 0)){
+      } else if(currentPhase === 1 || currentPhase === 2){
         switchAudios.dive.currentTime = 0;
         switchAudios.dive.play().catch(()=>{});
         startEnvSound("underwater");
@@ -1177,9 +1177,11 @@ function handleMusic(forceStop=false){
         playSwitchSound();
         playEnv(duration,0,1);
       } else if(currentPhase === 1){
+        if(selectedEnvs.includes("underwater")) startEnvSound("underwater");
         playSwitchSound();
         playEnv(duration,1,1);
       } else if(currentPhase === 2){
+        if(selectedEnvs.includes("underwater")) startEnvSound("underwater");
         playSwitchSound();
         playEnv(duration,1,0);
       } else if(currentPhase === 3){


### PR DESCRIPTION
## Summary
- ensure `underwater` ambience audio resumes during hold and exhale phases
- always trigger the dive audio when `underwater` environment is active in those phases

## Testing
- `htmlhint --rules "tagname-lowercase:false" deep_breath_illumination_merged.html`

------
https://chatgpt.com/codex/tasks/task_e_684f88d3dc488326a2eca9bd7ce93e59