### PR TITLE
Add directional light scaling and background color customization

### DIFF
--- a/Demo1.html
+++ b/Demo1.html
@@ -133,6 +133,7 @@ select,input[type="number"],input[type="color"]{
   pointer-events:none;
   z-index:1;
   display:none;
+  perspective:800px;
   color:#fff;
   transform:scale(0);
   transform-origin:center;
@@ -363,11 +364,13 @@ button:disabled{opacity:.6}
 
   <div class="section" id="modeSection">
     <h3>光の表現</h3>
-    <div class="mode-buttons scroll-buttons">
-      <button type="button" class="modeBtn" data-mode="off"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="1" width="22" height="22" fill="none" stroke="#fff" stroke-width="0.5"/><line x1="4" y1="4" x2="20" y2="20" stroke="#fff" stroke-width="0.5"/></svg> なし</button>
-      <button type="button" class="modeBtn active" data-mode="expand"><img src="光の広がり.gif" alt=""> 拡縮</button>
-      <button type="button" class="modeBtn" data-mode="fade"><img src="フェード.gif" alt=""> フェード</button>
-    </div>
+      <div class="mode-buttons scroll-buttons">
+        <button type="button" class="modeBtn" data-mode="off"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="1" width="22" height="22" fill="none" stroke="#fff" stroke-width="0.5"/><line x1="4" y1="4" x2="20" y2="20" stroke="#fff" stroke-width="0.5"/></svg> なし</button>
+        <button type="button" class="modeBtn active" data-mode="expand-center"><img src="光の広がり.gif" alt=""> 中央からの拡縮</button>
+        <button type="button" class="modeBtn" data-mode="expand-left"><img src="光の広がり.gif" alt=""> 左からの拡縮</button>
+        <button type="button" class="modeBtn" data-mode="expand-right"><img src="光の広がり.gif" alt=""> 右からの拡縮</button>
+        <button type="button" class="modeBtn" data-mode="fade"><img src="フェード.gif" alt=""> フェード</button>
+      </div>
   </div>
   <div class="section" id="colorChangeSection">
     <h3>色変化</h3>
@@ -375,6 +378,11 @@ button:disabled{opacity:.6}
       <button type="button" class="colorBtn active" data-color="off"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="1" width="22" height="22" fill="none" stroke="#fff" stroke-width="0.5"/><line x1="4" y1="4" x2="20" y2="20" stroke="#fff" stroke-width="0.5"/></svg> なし</button>
       <button type="button" class="colorBtn" data-color="on"><img src="色変化.gif" alt=""> あり</button>
     </div>
+  </div>
+  <div class="section" id="bgColorSection">
+    <h3>背景色</h3>
+    <button type="button" id="bgColorBtn">色を選択</button>
+    <input type="color" id="bgColorInput" value="#444444" style="display:none;">
   </div>
   <div class="section">
     <h3>環境音</h3>
@@ -465,15 +473,17 @@ button:disabled{opacity:.6}
   const envBtns       = document.querySelectorAll('.envBtn');
   const switchBtns    = document.querySelectorAll('.switchBtn');
   const musicBtns     = document.querySelectorAll('.musicBtn');
-  const fragranceBtns = document.querySelectorAll('.fragranceBtn');
-  const barContainer  = document.getElementById('barContainer');
-  const breathPlane   = document.getElementById('breathPlane');
-  const breathCube    = document.getElementById('breathCube');
-  const modeSection   = document.getElementById('modeSection');
-  const grayArea      = document.getElementById('grayArea');
-  const mainContainer = document.querySelector('.container');
-  const envContainer  = document.querySelector('.env-buttons');
-  const bubbleContainer = document.getElementById('bubbleContainer');
+    const fragranceBtns = document.querySelectorAll('.fragranceBtn');
+    const barContainer  = document.getElementById('barContainer');
+    const breathPlane   = document.getElementById('breathPlane');
+    const breathCube    = document.getElementById('breathCube');
+    const modeSection   = document.getElementById('modeSection');
+    const grayArea      = document.getElementById('grayArea');
+    const mainContainer = document.querySelector('.container');
+    const bgColorBtn    = document.getElementById('bgColorBtn');
+    const bgColorInput  = document.getElementById('bgColorInput');
+    const envContainer  = document.querySelector('.env-buttons');
+    const bubbleContainer = document.getElementById('bubbleContainer');
   const bubbleButtons = bubbleContainer.querySelectorAll('.bubble');
   bubbleButtons.forEach(btn=>{
     btn.style.animationDelay = `${Math.random()*4}s`;
@@ -508,6 +518,28 @@ button:disabled{opacity:.6}
     document.body.style.background = `#000 url('${url}') center/cover no-repeat fixed`;
   }
 
+  function setBarOrigin(){
+    if(mode==='expand-left'){
+      breathBar.style.left='0';
+      breathBar.style.transform='none';
+      breathBar.style.transformOrigin='left';
+    }else if(mode==='expand-right'){
+      breathBar.style.left='100%';
+      breathBar.style.transform='translateX(-100%)';
+      breathBar.style.transformOrigin='right';
+    }else{
+      breathBar.style.left='50%';
+      breathBar.style.transform='translateX(-50%)';
+      breathBar.style.transformOrigin='center';
+    }
+  }
+
+  function applyBgColor(color){
+    barContainer.style.background = color;
+    grayArea.style.background = color;
+    breathCube.style.background = color;
+  }
+
   const recommendedMap = {
     '4-7-8-0': '4セット',
     '4-4-4-4': '3分',
@@ -520,7 +552,7 @@ button:disabled{opacity:.6}
   let timerId = null;
   let currentPhase = 0;
   let prevPhase = 0;
-  let mode = 'expand';
+  let mode = 'expand-center';
   let shape = 'line';
   let speed = 'linear';
   let gradient = gradientSel.value;
@@ -693,6 +725,7 @@ button:disabled{opacity:.6}
       breathCube.style.display='none';
       grayArea.style.display='none';
       modeSection.style.display='';
+      setBarOrigin();
     }else if(shape==='plane'){
       barContainer.style.display='none';
       breathPlane.style.display='block';
@@ -740,22 +773,28 @@ button:disabled{opacity:.6}
       gradientSel.value = gradient;
     });
   });
-  colorBtns.forEach(btn=>{
-    if(btn.dataset.color===colorChange) btn.classList.add('active');
-    btn.addEventListener('click',()=>{
-      colorBtns.forEach(b=>b.classList.remove('active'));
-      btn.classList.add('active');
-      colorChange = btn.dataset.color;
-      colorChangeSel.value = colorChange;
-      updateColorRow();
+    colorBtns.forEach(btn=>{
+      if(btn.dataset.color===colorChange) btn.classList.add('active');
+      btn.addEventListener('click',()=>{
+        colorBtns.forEach(b=>b.classList.remove('active'));
+        btn.classList.add('active');
+        colorChange = btn.dataset.color;
+        colorChangeSel.value = colorChange;
+        updateColorRow();
+      });
     });
-  });
-  modeBtns.forEach(btn => {
-    if(btn.dataset.mode===mode) btn.classList.add('active');
-    btn.addEventListener('click', () => {
-      modeBtns.forEach(b=>b.classList.remove('active'));
-      btn.classList.add('active');
-      mode = btn.dataset.mode;
+
+    bgColorBtn.addEventListener('click',()=>bgColorInput.click());
+    bgColorInput.addEventListener('input',()=>applyBgColor(bgColorInput.value));
+    applyBgColor(bgColorInput.value);
+
+    modeBtns.forEach(btn => {
+      if(btn.dataset.mode===mode) btn.classList.add('active');
+      btn.addEventListener('click', () => {
+        modeBtns.forEach(b=>b.classList.remove('active'));
+        btn.classList.add('active');
+        mode = btn.dataset.mode;
+      setBarOrigin();
       updateColorRow();
     });
   });
@@ -1075,7 +1114,7 @@ function handleMusic(forceStop=false){
 
     phaseText.textContent = phaseNames[currentPhase] || '';
     if(shape === 'line'){
-      if(mode === 'expand'){
+      if(mode.startsWith('expand')){
         setBar(currentPhase < 2 ? 100 : 0, duration, color, 0.8);
       } else if(mode === 'fade') {
         if(gradient==='on'){
@@ -1117,7 +1156,7 @@ function handleMusic(forceStop=false){
         setBar(0, 0, 'transparent', 0);
       }
     } else if(shape === 'plane'){
-      if(mode === 'expand'){
+      if(mode.startsWith('expand')){
         setPlane(currentPhase < 2 ? 1 : 0, duration, color, 0.8);
       } else if(mode === 'fade'){
         if(gradient==='on'){
@@ -1159,7 +1198,7 @@ function handleMusic(forceStop=false){
         setPlane(0, 0, 'transparent', 0);
       }
     } else if(shape === 'cube'){
-      if(mode === 'expand'){
+      if(mode.startsWith('expand')){
         setCube(currentPhase < 2 ? 1 : 0, duration, color, 0.8);
       } else if(mode === 'fade'){
         if(gradient==='on'){


### PR DESCRIPTION
## Summary
- Rename existing light expansion to center-based and add left/right expansion options
- Allow users to choose light bar/plane/cube background color via new control
- Restore proper cube appearance with CSS perspective

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c8c872f48326a289720fda9e61f8