### PR TITLE
Add size controls for light shapes in Demo1

### DIFF
--- a/Demo1.html
+++ b/Demo1.html
@@ -378,6 +378,12 @@ button:disabled{opacity:.6}
       <button type="button" class="shapeBtn" data-shape="plane"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" fill="#fff"/></svg> 面</button>
       <button type="button" class="shapeBtn" data-shape="cube"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L4 6v12l8 4 8-4V6l-8-4z" fill="none" stroke="#fff" stroke-width="0.2"/><path d="M4 6l8 4 8-4" fill="none" stroke="#fff" stroke-width="0.2"/><path d="M12 10v12" fill="none" stroke="#fff" stroke-width="0.2"/></svg> 立体</button>
     </div>
+    <div id="shapeSizeInputs">
+      <label for="shapeWidth">横サイズ(%)</label>
+      <input type="number" id="shapeWidth" value="100" min="1" max="100">
+      <label for="shapeHeight">縦サイズ(%)</label>
+      <input type="number" id="shapeHeight" value="100" min="1" max="100">
+    </div>
   </div>
 
   <div class="section" id="gradientSection">
@@ -520,6 +526,9 @@ button:disabled{opacity:.6}
     const bgColorInput  = document.getElementById('bgColorInput');
     const envContainer  = document.querySelector('.env-buttons');
     const bubbleContainer = document.getElementById('bubbleContainer');
+    const shapeWidthInput  = document.getElementById('shapeWidth');
+    const shapeHeightInput = document.getElementById('shapeHeight');
+    const shapeSizeInputs  = document.getElementById('shapeSizeInputs');
   const bubbleButtons = bubbleContainer.querySelectorAll('.bubble');
   bubbleButtons.forEach(btn=>{
     btn.style.animationDelay = `${Math.random()*4}s`;
@@ -529,6 +538,7 @@ button:disabled{opacity:.6}
   });
   let selectedEnvs = [];
   let lastEnv = 'off';
+  let baseSize = 0;
   const canonMinutes = 431.654/60;
   const ariaMinutes  = 355.66/60;
   const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
@@ -747,20 +757,34 @@ button:disabled{opacity:.6}
   });
   updateBackground();
   function updateGrayAreaDims(){
+    const wPercent = parseFloat(shapeWidthInput.value) || 100;
+    const hPercent = parseFloat(shapeHeightInput.value) || 100;
+    const barBaseHeight = 60;
+    barContainer.style.width = wPercent + '%';
+    barContainer.style.height = (barBaseHeight * hPercent / 100) + 'px';
+    barContainer.style.left = '50%';
+    barContainer.style.transform = 'translateX(-50%)';
     const barHeight = barContainer.offsetHeight;
     const containerTop = mainContainer.offsetTop;
-    const size = containerTop - barHeight*2;
-    grayArea.style.top = barHeight*2 + 'px';
-    grayArea.style.width = size + 'px';
-    grayArea.style.height = size + 'px';
+    baseSize = containerTop - barHeight*2;
+    const top = barHeight*2;
+    grayArea.style.top = top + 'px';
+    grayArea.style.width = baseSize + 'px';
+    grayArea.style.height = baseSize + 'px';
     grayArea.style.marginLeft = '0px';
-    const center = barHeight*2 + size/2;
+    const center = top + baseSize/2;
+    const planeW = baseSize * wPercent / 100;
+    const planeH = baseSize * hPercent / 100;
     breathPlane.style.top = center + 'px';
     breathCube.style.top = center + 'px';
-    breathPlane.style.maxWidth = size + 'px';
-    breathPlane.style.maxHeight = size + 'px';
-    breathCube.style.maxWidth = size + 'px';
-    breathCube.style.maxHeight = size + 'px';
+    breathPlane.style.width = planeW + 'px';
+    breathPlane.style.height = planeH + 'px';
+    breathCube.style.width = planeW + 'px';
+    breathCube.style.height = planeH + 'px';
+    breathPlane.style.marginLeft = -(planeW/2) + 'px';
+    breathPlane.style.marginTop = -(planeH/2) + 'px';
+    breathCube.style.marginLeft = -(planeW/2) + 'px';
+    breathCube.style.marginTop = -(planeH/2) + 'px';
   }
   window.addEventListener('resize',updateGrayAreaDims);
   updateGrayAreaDims();
@@ -771,6 +795,7 @@ button:disabled{opacity:.6}
       breathCube.style.display='none';
       grayArea.style.display='none';
       modeSection.style.display='';
+      shapeSizeInputs.style.display='';
       setBarOrigin();
     }else if(shape==='plane'){
       barContainer.style.display='none';
@@ -778,18 +803,21 @@ button:disabled{opacity:.6}
       breathCube.style.display='none';
       grayArea.style.display='block';
       modeSection.style.display='';
+      shapeSizeInputs.style.display='';
     }else if(shape==='cube'){
       barContainer.style.display='none';
       breathPlane.style.display='none';
       breathCube.style.display='block';
       grayArea.style.display='none';
       modeSection.style.display='';
+      shapeSizeInputs.style.display='';
     }else{
       barContainer.style.display='none';
       breathPlane.style.display='none';
       breathCube.style.display='none';
       grayArea.style.display='none';
       modeSection.style.display='none';
+      shapeSizeInputs.style.display='none';
     }
   }
   updateShapeVisibility();
@@ -800,8 +828,11 @@ button:disabled{opacity:.6}
       btn.classList.add('active');
       shape = btn.dataset.shape;
       updateShapeVisibility();
+      updateGrayAreaDims();
     });
   });
+  shapeWidthInput.addEventListener('input', updateGrayAreaDims);
+  shapeHeightInput.addEventListener('input', updateGrayAreaDims);
   speedBtns.forEach(btn=>{
     if(btn.dataset.speed===speed) btn.classList.add('active');
     btn.addEventListener('click',()=>{


### PR DESCRIPTION
## Summary
- add horizontal and vertical size inputs under the light shape section
- resize bar, plane, and cube according to new controls and toggle visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f0fb79fc832692e399fb96b1cfdb